### PR TITLE
Phase 3: sleep timer, favorites export, and the stream recorder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,12 @@ dependencies = [
 
 [[package]]
 name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+
+[[package]]
+name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
@@ -876,12 +882,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1355,6 +1385,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flacenc"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c892c2b5fa08f967e8b5ad29121570b4762202f2402033ce08479ec65eccd0"
+dependencies = [
+ "built 0.7.7",
+ "crc",
+ "crossbeam-channel",
+ "heapless",
+ "log",
+ "md-5",
+ "num-traits",
+ "rustversion",
+ "seq-macro",
+ "serde",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,6 +1658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1684,17 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2349,6 +2417,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,6 +3066,7 @@ dependencies = [
 name = "plaza-audio"
 version = "0.1.0"
 dependencies = [
+ "flacenc",
  "m3u8-rs",
  "opus",
  "reqwest",
@@ -3433,7 +3512,7 @@ dependencies = [
  "av-scenechange",
  "av1-grain",
  "bitstream-io",
- "built",
+ "built 0.8.0",
  "cfg-if",
  "interpolate_name",
  "itertools 0.14.0",
@@ -3853,6 +3932,12 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ symphonia = { version = "0.5", features = ["aac", "mp3", "ogg", "isomp4"] }
 rodio = { version = "0.19", default-features = false, features = ["symphonia-all"] }
 opus = "0.3"
 m3u8-rs = "6"
+flacenc = "0.5"
 
 # TUI
 ratatui = "0.30"

--- a/crates/plaza-api/src/client.rs
+++ b/crates/plaza-api/src/client.rs
@@ -66,6 +66,18 @@ impl ApiClient {
         }
     }
 
+    /// Request an export of the signed-in user's favourites, returning a download link.
+    pub async fn export_favorites(&self) -> Result<String> {
+        let url = self.url("v2/users/me/favorites/export");
+        let resp = self.auth_request(Method::POST, &url).send().await?;
+        let value: serde_json::Value = self.handle_response(resp).await?;
+        value
+            .get("link")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .ok_or_else(|| Error::Unexpected("missing export link".to_string()))
+    }
+
     /// Send a reaction for the current song, returning the new reaction total.
     pub async fn send_reaction(&self, reaction: u8) -> Result<u32> {
         let url = self.url("v2/reactions");

--- a/crates/plaza-api/tests/client_test.rs
+++ b/crates/plaza-api/tests/client_test.rs
@@ -81,6 +81,24 @@ async fn add_favorite_posts_song_id_and_returns_entry() {
 }
 
 #[tokio::test]
+async fn export_favorites_returns_link() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v2/users/me/favorites/export"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "link": "https://x/export.zip" })),
+        )
+        .mount(&server)
+        .await;
+
+    let client = ApiClient::new(Some("t".to_string())).with_base_url(&server.uri());
+    assert_eq!(
+        client.export_favorites().await.unwrap(),
+        "https://x/export.zip"
+    );
+}
+
+#[tokio::test]
 async fn send_reaction_returns_updated_total() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))

--- a/crates/plaza-audio/Cargo.toml
+++ b/crates/plaza-audio/Cargo.toml
@@ -16,3 +16,4 @@ reqwest.workspace = true
 serde.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
+flacenc.workspace = true

--- a/crates/plaza-audio/src/lib.rs
+++ b/crates/plaza-audio/src/lib.rs
@@ -36,3 +36,4 @@ pub use error::{Error, Result};
 pub use pcm::{PcmChunk, PcmError, PcmSource};
 pub use player::Player;
 pub use quality::StreamQuality;
+pub use recording::{RecordMode, RecordingConfig};

--- a/crates/plaza-audio/src/lib.rs
+++ b/crates/plaza-audio/src/lib.rs
@@ -28,6 +28,7 @@ pub mod hls;
 pub mod pcm;
 pub mod player;
 pub mod quality;
+pub mod recording;
 pub mod sources;
 pub mod ts;
 

--- a/crates/plaza-audio/src/player.rs
+++ b/crates/plaza-audio/src/player.rs
@@ -15,6 +15,7 @@ use rodio::{OutputStream, OutputStreamHandle, Sink};
 use crate::error::{Error, Result};
 use crate::pcm::{PcmChunk, PcmError, PcmSource};
 use crate::quality::StreamQuality;
+use crate::recording::{RecordMode, Recorder, RecordingConfig};
 use crate::sources::{build_live_source, build_preview_source};
 
 /// A callback the audio thread invokes with a human-readable message when playback
@@ -42,6 +43,7 @@ pub struct Player {
     task_handle: Option<std::thread::JoinHandle<()>>,
     cmd_tx: Option<std::sync::mpsc::SyncSender<PlayerCommand>>,
     error_report: Option<ErrorReporter>,
+    recorder: Option<Recorder>,
     volume: f32,
     is_playing: bool,
 }
@@ -71,9 +73,50 @@ impl Player {
             task_handle: None,
             cmd_tx: None,
             error_report: None,
+            recorder: None,
             volume: 0.8,
             is_playing: false,
         })
+    }
+
+    /// Start the recorder, which captures completed songs from supported (Opus)
+    /// live streams. Spawns a background recorder thread; safe to call with
+    /// [`RecordMode::Off`] so recording can be toggled on later.
+    pub fn configure_recording(&mut self, config: RecordingConfig) {
+        self.recorder = Some(Recorder::spawn(config));
+    }
+
+    /// The current recording mode ([`RecordMode::Off`] if recording isn't configured).
+    pub fn recording_mode(&self) -> RecordMode {
+        self.recorder
+            .as_ref()
+            .map_or(RecordMode::Off, Recorder::mode)
+    }
+
+    /// Advance recording to its next mode (off → cache → session → off), returning it.
+    pub fn cycle_recording_mode(&mut self) -> RecordMode {
+        match &mut self.recorder {
+            Some(r) => {
+                let mode = r.mode().next();
+                r.set_mode(mode);
+                mode
+            }
+            None => RecordMode::Off,
+        }
+    }
+
+    /// Promote the most recently cached song into the permanent library.
+    pub fn keep_recording(&self) {
+        if let Some(r) = &self.recorder {
+            r.keep();
+        }
+    }
+
+    /// Update the now-playing artwork URL used to tag songs as they're recorded.
+    pub fn set_now_playing_artwork(&self, url: Option<String>) {
+        if let Some(r) = &self.recorder {
+            r.set_artwork(url);
+        }
     }
 
     /// Register a callback for unrecoverable playback failures (e.g. an undecodable
@@ -92,7 +135,8 @@ impl Player {
     /// Returns [`Error::Output`] if the playback sink or thread cannot be created.
     /// A bad stream surfaces later through the [`on_error`](Self::on_error) callback.
     pub fn start_live(&mut self, quality: StreamQuality) -> Result<()> {
-        let factory = move || build_live_source(&quality);
+        let rec = self.recorder.as_ref().map(Recorder::handle);
+        let factory = move || build_live_source(&quality, rec.clone());
         self.start_with_factory(factory, StreamMode::Live)
     }
 

--- a/crates/plaza-audio/src/quality.rs
+++ b/crates/plaza-audio/src/quality.rs
@@ -37,6 +37,13 @@ impl StreamQuality {
         }
     }
 
+    /// Whether songs can be recorded from this stream. Only Opus carries exact
+    /// in-band song boundaries, so it's the only format the recorder can split
+    /// losslessly.
+    pub fn is_recordable(self) -> bool {
+        matches!(self, StreamQuality::Ogg | StreamQuality::OggLow)
+    }
+
     /// A short human-readable label, e.g. for status messages.
     pub fn label(self) -> &'static str {
         match self {

--- a/crates/plaza-audio/src/recording/flac.rs
+++ b/crates/plaza-audio/src/recording/flac.rs
@@ -1,0 +1,257 @@
+//! FLAC encoding with Vorbis-comment tags and an optional embedded cover image.
+//!
+//! [`flacenc`] encodes the audio but doesn't expose the `VORBIS_COMMENT` or
+//! `PICTURE` metadata blocks, so we splice those into the stream ourselves: both
+//! are simple, well-specified blocks that sit right after `STREAMINFO`.
+
+use flacenc::component::BitRepr;
+use flacenc::error::Verify;
+
+use super::{Error, Result};
+
+/// An embedded cover image.
+pub struct Picture {
+    /// MIME type, e.g. `"image/jpeg"`.
+    pub mime: String,
+    /// Raw image bytes.
+    pub data: Vec<u8>,
+}
+
+/// FLAC `STREAMINFO` is metadata block type 0, `VORBIS_COMMENT` is 4, `PICTURE` is 6.
+const BLOCK_VORBIS_COMMENT: u8 = 4;
+const BLOCK_PICTURE: u8 = 6;
+
+/// Encode interleaved f32 PCM to a complete FLAC byte stream, tagged with `comments`
+/// (e.g. `("ARTIST", "…")`) and an optional embedded `cover`.
+///
+/// Samples are quantized to 16-bit, which matches Plaza's source material.
+///
+/// # Errors
+/// Returns [`Error::Config`] or [`Error::Encode`] if the encoder rejects the input.
+pub fn encode_flac(
+    samples: &[f32],
+    channels: u16,
+    sample_rate: u32,
+    comments: &[(&str, &str)],
+    cover: Option<&Picture>,
+) -> Result<Vec<u8>> {
+    let pcm: Vec<i32> = samples
+        .iter()
+        .map(|&x| (x.clamp(-1.0, 1.0) * f32::from(i16::MAX)).round() as i32)
+        .collect();
+
+    let config = flacenc::config::Encoder::default()
+        .into_verified()
+        .map_err(|(_, e)| Error::Config(e.to_string()))?;
+    let source =
+        flacenc::source::MemSource::from_samples(&pcm, channels as usize, 16, sample_rate as usize);
+    let stream = flacenc::encode_with_fixed_block_size(&config, source, 4096)
+        .map_err(|e| Error::Encode(e.to_string()))?;
+
+    let mut sink = flacenc::bitsink::ByteSink::new();
+    stream
+        .write(&mut sink)
+        .map_err(|e| Error::Encode(e.to_string()))?;
+
+    splice_metadata(sink.into_inner(), comments, cover)
+}
+
+/// Insert `VORBIS_COMMENT` (and an optional `PICTURE`) after the encoder's existing
+/// metadata blocks, fixing up the "last metadata block" flags. Robust to whatever
+/// blocks (STREAMINFO, padding, …) the encoder already emitted.
+fn splice_metadata(
+    flac: Vec<u8>,
+    comments: &[(&str, &str)],
+    cover: Option<&Picture>,
+) -> Result<Vec<u8>> {
+    if flac.len() < 8 || &flac[0..4] != b"fLaC" {
+        return Err(Error::Encode(
+            "encoder did not produce a FLAC stream".into(),
+        ));
+    }
+
+    // Walk the metadata blocks to find where they end (start of the audio frames)
+    // and the header offset of the current last block.
+    let mut pos = 4;
+    let mut last_header;
+    loop {
+        if pos + 4 > flac.len() {
+            return Err(Error::Encode("truncated metadata block header".into()));
+        }
+        let is_last = flac[pos] & 0x80 != 0;
+        let len = u32::from_be_bytes([0, flac[pos + 1], flac[pos + 2], flac[pos + 3]]) as usize;
+        last_header = pos;
+        pos += 4 + len;
+        if pos > flac.len() {
+            return Err(Error::Encode("truncated metadata block".into()));
+        }
+        if is_last {
+            break;
+        }
+    }
+    let frames_start = pos;
+
+    let mut blocks: Vec<(u8, Vec<u8>)> =
+        vec![(BLOCK_VORBIS_COMMENT, vorbis_comment_block(comments))];
+    if let Some(pic) = cover {
+        blocks.push((BLOCK_PICTURE, picture_block(pic)));
+    }
+
+    let extra: usize = blocks.iter().map(|(_, d)| d.len() + 4).sum();
+    let mut out = Vec::with_capacity(flac.len() + extra);
+    out.extend_from_slice(&flac[..frames_start]);
+    // The block that used to be last is no longer last.
+    out[last_header] &= 0x7F;
+
+    // flacenc emits fixed-blocking frames but writes a STREAMINFO that declares
+    // variable blocking (min_block_size != max_block_size, the former being the short
+    // final block). Strict readers (symphonia) then expect sample-numbered frame
+    // headers and desync. The frames are genuinely fixed, so make STREAMINFO agree by
+    // setting min_block_size = max_block_size. STREAMINFO is the first block; its data
+    // begins at offset 8, with min/max block size in the first four bytes.
+    if flac[4] & 0x7F == 0 {
+        let (min, max) = out.split_at_mut(10);
+        min[8..10].copy_from_slice(&max[0..2]);
+    }
+    for (i, (block_type, data)) in blocks.iter().enumerate() {
+        let last = i == blocks.len() - 1;
+        out.push(if last { 0x80 } else { 0 } | (block_type & 0x7F));
+        out.extend_from_slice(&u24_be(data.len()));
+        out.extend_from_slice(data);
+    }
+    out.extend_from_slice(&flac[frames_start..]);
+    Ok(out)
+}
+
+/// Build a `VORBIS_COMMENT` block body (little-endian lengths, no framing bit).
+fn vorbis_comment_block(comments: &[(&str, &str)]) -> Vec<u8> {
+    const VENDOR: &[u8] = b"plaza-tui";
+    let mut d = Vec::new();
+    d.extend_from_slice(&(VENDOR.len() as u32).to_le_bytes());
+    d.extend_from_slice(VENDOR);
+    d.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+    for (key, value) in comments {
+        let entry = format!("{key}={value}");
+        d.extend_from_slice(&(entry.len() as u32).to_le_bytes());
+        d.extend_from_slice(entry.as_bytes());
+    }
+    d
+}
+
+/// Build a `PICTURE` block body (big-endian; type 3 = front cover).
+fn picture_block(pic: &Picture) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(&3u32.to_be_bytes()); // picture type: front cover
+    d.extend_from_slice(&(pic.mime.len() as u32).to_be_bytes());
+    d.extend_from_slice(pic.mime.as_bytes());
+    d.extend_from_slice(&0u32.to_be_bytes()); // empty description
+                                              // width, height, color depth, colors used — 0 = unspecified.
+    d.extend_from_slice(&[0u8; 16]);
+    d.extend_from_slice(&(pic.data.len() as u32).to_be_bytes());
+    d.extend_from_slice(&pic.data);
+    d
+}
+
+fn u24_be(n: usize) -> [u8; 3] {
+    [(n >> 16) as u8, (n >> 8) as u8, n as u8]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use symphonia::core::audio::SampleBuffer;
+    use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
+    use symphonia::core::formats::FormatOptions;
+    use symphonia::core::io::MediaSourceStream;
+    use symphonia::core::meta::MetadataOptions;
+    use symphonia::core::probe::Hint;
+
+    /// One second of a 440 Hz stereo tone.
+    fn tone() -> (Vec<f32>, u32, u16) {
+        let rate = 48_000u32;
+        let mut s = Vec::with_capacity(rate as usize * 2);
+        for i in 0..rate as usize {
+            let v = (i as f32 * 440.0 * std::f32::consts::TAU / rate as f32).sin() * 0.5;
+            s.push(v);
+            s.push(v);
+        }
+        (s, rate, 2)
+    }
+
+    /// Decode FLAC bytes with symphonia and return the per-channel frame count.
+    fn decode_frames(flac: &[u8]) -> u64 {
+        let mss = MediaSourceStream::new(
+            Box::new(std::io::Cursor::new(flac.to_vec())),
+            Default::default(),
+        );
+        let mut hint = Hint::new();
+        hint.with_extension("flac");
+        let probed = symphonia::default::get_probe()
+            .format(
+                &hint,
+                mss,
+                &FormatOptions::default(),
+                &MetadataOptions::default(),
+            )
+            .expect("our FLAC output must be decodable by symphonia");
+        let mut format = probed.format;
+        let track = format
+            .tracks()
+            .iter()
+            .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+            .expect("audio track");
+        let track_id = track.id;
+        let mut decoder = symphonia::default::get_codecs()
+            .make(&track.codec_params, &DecoderOptions::default())
+            .expect("flac decoder");
+        let mut frames = 0u64;
+        while let Ok(packet) = format.next_packet() {
+            if packet.track_id() != track_id {
+                continue;
+            }
+            if let Ok(decoded) = decoder.decode(&packet) {
+                let mut sb = SampleBuffer::<f32>::new(decoded.capacity() as u64, *decoded.spec());
+                sb.copy_interleaved_ref(decoded);
+                frames += (sb.samples().len() / 2) as u64;
+            }
+        }
+        frames
+    }
+
+    #[test]
+    fn round_trips_to_lossless_audio_of_the_same_length() {
+        let (samples, rate, ch) = tone();
+        let flac = encode_flac(&samples, ch, rate, &[("ARTIST", "Test")], None).unwrap();
+        assert_eq!(&flac[0..4], b"fLaC");
+        // Lossless: exactly one second of stereo frames back out.
+        assert_eq!(decode_frames(&flac), rate as u64);
+    }
+
+    #[test]
+    fn embeds_vorbis_comments_and_a_picture() {
+        let (samples, rate, ch) = tone();
+        let cover = Picture {
+            mime: "image/jpeg".into(),
+            data: vec![0xFF, 0xD8, 0xFF, 0xD9],
+        };
+        let flac = encode_flac(
+            &samples,
+            ch,
+            rate,
+            &[("ARTIST", "la trace"), ("TITLE", "Man Enough")],
+            Some(&cover),
+        )
+        .unwrap();
+
+        // The comment strings and picture MIME are present verbatim in the blocks.
+        assert!(contains(&flac, b"ARTIST=la trace"));
+        assert!(contains(&flac, b"TITLE=Man Enough"));
+        assert!(contains(&flac, b"image/jpeg"));
+        // Audio still decodes after the metadata splice.
+        assert_eq!(decode_frames(&flac), rate as u64);
+    }
+
+    fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
+    }
+}

--- a/crates/plaza-audio/src/recording/mod.rs
+++ b/crates/plaza-audio/src/recording/mod.rs
@@ -6,6 +6,10 @@
 //! correctness guarantees in `tasks/recording-design.md`.
 
 pub mod flac;
+pub mod recorder;
+
+pub(crate) use recorder::Recorder;
+pub use recorder::{RecordHandle, RecordMode, RecordingConfig, SongTags};
 
 /// An error while encoding or writing a recording.
 #[derive(Debug, thiserror::Error)]

--- a/crates/plaza-audio/src/recording/mod.rs
+++ b/crates/plaza-audio/src/recording/mod.rs
@@ -1,0 +1,26 @@
+//! Capturing the live stream into a local, tagged FLAC library.
+//!
+//! Songs arrive as a continuous PCM stream; the recorder relies on exact, in-band
+//! song boundaries (each Plaza Opus song is its own chained-Ogg logical stream) to
+//! split them losslessly. A captured song is only ever persisted in full — see the
+//! correctness guarantees in `tasks/recording-design.md`.
+
+pub mod flac;
+
+/// An error while encoding or writing a recording.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// The FLAC encoder rejected its configuration.
+    #[error("flac configuration error: {0}")]
+    Config(String),
+    /// Encoding the audio to FLAC failed.
+    #[error("flac encode error: {0}")]
+    Encode(String),
+    /// Writing the file to disk failed.
+    #[error("i/o error")]
+    Io(#[from] std::io::Error),
+}
+
+/// Result alias for recording operations.
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/plaza-audio/src/recording/recorder.rs
+++ b/crates/plaza-audio/src/recording/recorder.rs
@@ -1,0 +1,476 @@
+//! The recorder: turns a stream of decode events into a tagged FLAC library.
+//!
+//! The decode thread emits record events (a song began, here are its samples, it
+//! ended cleanly, or it was interrupted). A dedicated recorder thread accumulates
+//! each song's PCM and, on a clean finish, encodes and writes it — so the
+//! CPU-heavy encode never runs on the playback path.
+//!
+//! Correctness (see `tasks/recording-design.md`): a song is written only if it was
+//! captured from its start *and* ended cleanly; writes are atomic (temp file then
+//! rename) so the library never contains a partial file.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+
+use super::flac::{encode_flac, Picture};
+use crate::pcm::PcmChunk;
+
+/// What the recorder does with completed songs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RecordMode {
+    /// Not recording.
+    #[default]
+    Off,
+    /// Keep a rolling cache of the most recent songs; promote with "keep".
+    Cache,
+    /// Write every completed song straight to the library.
+    Session,
+}
+
+impl RecordMode {
+    /// The next mode when cycling Off → Cache → Session → Off.
+    pub fn next(self) -> RecordMode {
+        match self {
+            RecordMode::Off => RecordMode::Cache,
+            RecordMode::Cache => RecordMode::Session,
+            RecordMode::Session => RecordMode::Off,
+        }
+    }
+
+    /// A short label for the UI.
+    pub fn label(self) -> &'static str {
+        match self {
+            RecordMode::Off => "off",
+            RecordMode::Cache => "cache",
+            RecordMode::Session => "session",
+        }
+    }
+}
+
+/// Recorder configuration.
+#[derive(Debug, Clone)]
+pub struct RecordingConfig {
+    /// Starting mode.
+    pub mode: RecordMode,
+    /// Library root directory.
+    pub root: PathBuf,
+    /// How many songs the rolling cache retains.
+    pub cache_size: usize,
+    /// Whether to download and embed cover art.
+    pub embed_artwork: bool,
+    /// Skip writing a library file that already exists.
+    pub deduplicate: bool,
+}
+
+/// In-band metadata for a song, read from the stream.
+#[derive(Debug, Clone, Default)]
+pub struct SongTags {
+    /// Performing artist.
+    pub artist: Option<String>,
+    /// Album title.
+    pub album: Option<String>,
+    /// Track title.
+    pub title: Option<String>,
+}
+
+/// An event from the decode path to the recorder.
+pub(crate) enum RecordEvent {
+    /// A new song started. `savable` is false for the song already in progress when
+    /// recording (or the stream) began — we joined it mid-way, so it's incomplete.
+    Begin { tags: SongTags, savable: bool },
+    /// Decoded audio for the current song.
+    Samples(PcmChunk),
+    /// The current song ended cleanly at a boundary.
+    Finish,
+    /// The current song was interrupted; discard it.
+    Abort,
+    /// Promote the most recently cached song into the library.
+    Keep,
+    /// Change what completed songs are done with.
+    SetMode(RecordMode),
+}
+
+/// Handle the decode path uses to feed the recorder. Cloneable and cheap.
+///
+/// This is internal plumbing that appears in [`OpusPcmSource::open`](crate::sources::OpusPcmSource::open);
+/// it has no public constructor, so external callers only ever pass `None`.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct RecordHandle {
+    tx: Sender<RecordEvent>,
+    active: Arc<AtomicBool>,
+}
+
+impl RecordHandle {
+    /// Whether recording is currently on (so the source can skip cloning samples).
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn begin(&self, tags: SongTags, savable: bool) {
+        let _ = self.tx.send(RecordEvent::Begin { tags, savable });
+    }
+
+    pub(crate) fn samples(&self, chunk: PcmChunk) {
+        let _ = self.tx.send(RecordEvent::Samples(chunk));
+    }
+
+    pub(crate) fn finish(&self) {
+        let _ = self.tx.send(RecordEvent::Finish);
+    }
+
+    pub(crate) fn abort(&self) {
+        let _ = self.tx.send(RecordEvent::Abort);
+    }
+}
+
+/// Owns the recorder thread and the controls the player exposes.
+pub(crate) struct Recorder {
+    tx: Sender<RecordEvent>,
+    active: Arc<AtomicBool>,
+    /// Current now-playing artwork URL, snapshotted per song when it begins.
+    artwork: Arc<Mutex<Option<String>>>,
+    mode: RecordMode,
+    _thread: std::thread::JoinHandle<()>,
+}
+
+impl Recorder {
+    /// Spawn the recorder thread.
+    pub(crate) fn spawn(config: RecordingConfig) -> Self {
+        let (tx, rx) = channel();
+        let active = Arc::new(AtomicBool::new(config.mode != RecordMode::Off));
+        let artwork = Arc::new(Mutex::new(None));
+        let mode = config.mode;
+        let art_for_thread = Arc::clone(&artwork);
+        let thread = std::thread::Builder::new()
+            .name("plaza-recorder".to_string())
+            .spawn(move || recorder_loop(rx, config, art_for_thread))
+            .expect("spawning a thread should not fail");
+        Recorder {
+            tx,
+            active,
+            artwork,
+            mode,
+            _thread: thread,
+        }
+    }
+
+    /// A handle for the decode path to feed events through.
+    pub(crate) fn handle(&self) -> RecordHandle {
+        RecordHandle {
+            tx: self.tx.clone(),
+            active: Arc::clone(&self.active),
+        }
+    }
+
+    pub(crate) fn mode(&self) -> RecordMode {
+        self.mode
+    }
+
+    /// Change the recording mode, returning the new mode.
+    pub(crate) fn set_mode(&mut self, mode: RecordMode) {
+        self.mode = mode;
+        self.active
+            .store(mode != RecordMode::Off, Ordering::Relaxed);
+        let _ = self.tx.send(RecordEvent::SetMode(mode));
+    }
+
+    /// Promote the most recently cached song into the library.
+    pub(crate) fn keep(&self) {
+        let _ = self.tx.send(RecordEvent::Keep);
+    }
+
+    /// Update the now-playing artwork URL used to tag newly started songs.
+    pub(crate) fn set_artwork(&self, url: Option<String>) {
+        if let Ok(mut g) = self.artwork.lock() {
+            *g = url;
+        }
+    }
+}
+
+/// A song being accumulated in memory.
+struct Current {
+    tags: SongTags,
+    savable: bool,
+    artwork_url: Option<String>,
+    samples: Vec<f32>,
+    sample_rate: u32,
+    channels: u16,
+}
+
+fn recorder_loop(
+    rx: Receiver<RecordEvent>,
+    config: RecordingConfig,
+    artwork: Arc<Mutex<Option<String>>>,
+) {
+    let mut sink = RecordingSink::new(config);
+    let mut current: Option<Current> = None;
+
+    for event in rx {
+        match event {
+            RecordEvent::Begin { tags, savable } => {
+                // A new song beginning means any unfinished one was interrupted.
+                current = Some(Current {
+                    tags,
+                    savable,
+                    artwork_url: artwork.lock().ok().and_then(|g| g.clone()),
+                    samples: Vec::new(),
+                    sample_rate: 0,
+                    channels: 0,
+                });
+            }
+            RecordEvent::Samples(chunk) => {
+                if let Some(c) = &mut current {
+                    c.sample_rate = chunk.sample_rate;
+                    c.channels = chunk.channels;
+                    c.samples.extend_from_slice(&chunk.samples);
+                }
+            }
+            RecordEvent::Finish => {
+                if let Some(c) = current.take() {
+                    if c.savable && !c.samples.is_empty() {
+                        if let Err(e) = sink.write_song(&c) {
+                            tracing::warn!("recording: failed to save song: {e}");
+                        }
+                    }
+                }
+            }
+            RecordEvent::Abort => current = None,
+            RecordEvent::Keep => sink.keep_last(),
+            RecordEvent::SetMode(mode) => {
+                sink.mode = mode;
+                if mode == RecordMode::Off {
+                    current = None;
+                }
+            }
+        }
+    }
+    // Channel closed: any in-progress song is incomplete and is dropped unsaved.
+}
+
+/// Writes finished songs to disk and manages the rolling cache.
+struct RecordingSink {
+    mode: RecordMode,
+    root: PathBuf,
+    cache_size: usize,
+    embed_artwork: bool,
+    deduplicate: bool,
+    /// Cache files in eviction order (oldest first).
+    cache: VecDeque<PathBuf>,
+    /// The most recently written cache file and its tags, for "keep".
+    last_cached: Option<(PathBuf, SongTags)>,
+    http: reqwest::blocking::Client,
+}
+
+impl RecordingSink {
+    fn new(config: RecordingConfig) -> Self {
+        RecordingSink {
+            mode: config.mode,
+            root: config.root,
+            cache_size: config.cache_size.max(1),
+            embed_artwork: config.embed_artwork,
+            deduplicate: config.deduplicate,
+            cache: VecDeque::new(),
+            last_cached: None,
+            http: reqwest::blocking::Client::builder()
+                .user_agent(concat!("plaza-tui/", env!("CARGO_PKG_VERSION")))
+                .build()
+                .unwrap_or_default(),
+        }
+    }
+
+    fn write_song(&mut self, song: &Current) -> super::Result<()> {
+        match self.mode {
+            RecordMode::Off => Ok(()),
+            RecordMode::Session => {
+                let dest = library_path(&self.root, &song.tags);
+                if self.deduplicate && dest.exists() {
+                    return Ok(());
+                }
+                self.encode_to(song, &dest)
+            }
+            RecordMode::Cache => {
+                let dest = cache_path(&self.root, &song.tags);
+                self.encode_to(song, &dest)?;
+                self.cache.retain(|p| p != &dest);
+                self.cache.push_back(dest.clone());
+                self.last_cached = Some((dest, song.tags.clone()));
+                while self.cache.len() > self.cache_size {
+                    if let Some(old) = self.cache.pop_front() {
+                        let _ = std::fs::remove_file(old);
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Promote the most recently cached song into the permanent library.
+    fn keep_last(&mut self) {
+        let Some((cache_path, tags)) = self.last_cached.clone() else {
+            return;
+        };
+        let dest = library_path(&self.root, &tags);
+        if let Some(parent) = dest.parent() {
+            if std::fs::create_dir_all(parent).is_err() {
+                return;
+            }
+        }
+        if std::fs::rename(&cache_path, &dest).is_ok() {
+            self.cache.retain(|p| p != &cache_path);
+            self.last_cached = None;
+            tracing::info!("recording: kept {}", dest.display());
+        }
+    }
+
+    /// Encode a song and write it atomically (temp file then rename).
+    fn encode_to(&self, song: &Current, dest: &Path) -> super::Result<()> {
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut comments: Vec<(&str, &str)> = Vec::new();
+        if let Some(a) = &song.tags.artist {
+            comments.push(("ARTIST", a));
+        }
+        if let Some(a) = &song.tags.album {
+            comments.push(("ALBUM", a));
+        }
+        if let Some(t) = &song.tags.title {
+            comments.push(("TITLE", t));
+        }
+        comments.push(("SOURCE", "Nightwave Plaza"));
+
+        let cover = if self.embed_artwork {
+            song.artwork_url
+                .as_deref()
+                .and_then(|u| self.fetch_cover(u))
+        } else {
+            None
+        };
+
+        let flac = encode_flac(
+            &song.samples,
+            song.channels,
+            song.sample_rate,
+            &comments,
+            cover.as_ref(),
+        )?;
+
+        let tmp = dest.with_extension("flac.part");
+        std::fs::write(&tmp, &flac)?;
+        std::fs::rename(&tmp, dest)?;
+        tracing::info!("recording: wrote {}", dest.display());
+        Ok(())
+    }
+
+    fn fetch_cover(&self, url: &str) -> Option<Picture> {
+        let resp = self.http.get(url).send().ok()?.error_for_status().ok()?;
+        let mime = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.split(';').next().unwrap_or(s).trim().to_string())
+            .unwrap_or_else(|| "image/jpeg".to_string());
+        let data = resp.bytes().ok()?.to_vec();
+        if data.is_empty() {
+            return None;
+        }
+        Some(Picture { mime, data })
+    }
+}
+
+/// `<root>/<Artist>/<Album>/<Artist> - <Title>.flac`, each component sanitized.
+fn library_path(root: &Path, tags: &SongTags) -> PathBuf {
+    let artist = sanitize(tags.artist.as_deref().unwrap_or("Unknown Artist"));
+    let album = sanitize(tags.album.as_deref().unwrap_or("Unknown Album"));
+    let title = sanitize(tags.title.as_deref().unwrap_or("Untitled"));
+    root.join(&artist)
+        .join(&album)
+        .join(format!("{artist} - {title}.flac"))
+}
+
+/// A flat cache location: `<root>/.cache/<Artist> - <Title>.flac`.
+fn cache_path(root: &Path, tags: &SongTags) -> PathBuf {
+    let artist = sanitize(tags.artist.as_deref().unwrap_or("Unknown Artist"));
+    let title = sanitize(tags.title.as_deref().unwrap_or("Untitled"));
+    root.join(".cache").join(format!("{artist} - {title}.flac"))
+}
+
+/// Make a string safe to use as a single path component.
+fn sanitize(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .map(|c| {
+            if c.is_control() || matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|') {
+                '_'
+            } else {
+                c
+            }
+        })
+        .collect();
+    let trimmed = cleaned.trim().trim_end_matches('.').trim();
+    let capped: String = trimmed.chars().take(120).collect();
+    let capped = capped.trim().to_string();
+    if capped.is_empty() {
+        "Unknown".to_string()
+    } else {
+        capped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(artist: &str, album: &str, title: &str) -> SongTags {
+        SongTags {
+            artist: Some(artist.into()),
+            album: Some(album.into()),
+            title: Some(title.into()),
+        }
+    }
+
+    #[test]
+    fn library_path_uses_artist_album_title_tree() {
+        let p = library_path(
+            Path::new("/m"),
+            &tags("la trace", "LITE TOUCH", "Man Enough"),
+        );
+        assert_eq!(
+            p,
+            Path::new("/m/la trace/LITE TOUCH/la trace - Man Enough.flac")
+        );
+    }
+
+    #[test]
+    fn missing_tags_fall_back_to_placeholders() {
+        let p = library_path(Path::new("/m"), &SongTags::default());
+        assert_eq!(
+            p,
+            Path::new("/m/Unknown Artist/Unknown Album/Unknown Artist - Untitled.flac")
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_path_separators_and_control_chars() {
+        assert_eq!(sanitize("AC/DC"), "AC_DC");
+        assert_eq!(sanitize("a\nb:c"), "a_b_c");
+        assert_eq!(sanitize("  spaced.  "), "spaced");
+        assert_eq!(sanitize(""), "Unknown");
+        assert_eq!(sanitize("   "), "Unknown");
+    }
+
+    #[test]
+    fn mode_cycles_off_cache_session() {
+        assert_eq!(RecordMode::Off.next(), RecordMode::Cache);
+        assert_eq!(RecordMode::Cache.next(), RecordMode::Session);
+        assert_eq!(RecordMode::Session.next(), RecordMode::Off);
+    }
+}

--- a/crates/plaza-audio/src/sources.rs
+++ b/crates/plaza-audio/src/sources.rs
@@ -393,3 +393,100 @@ impl PcmSource for OpusPcmSource {
         }
     }
 }
+
+#[cfg(test)]
+mod recording_e2e {
+    use super::*;
+    use crate::quality::StreamQuality;
+    use crate::recording::{RecordMode, Recorder, RecordingConfig};
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, Instant};
+
+    fn first_flac(dir: &Path) -> Option<PathBuf> {
+        std::fs::read_dir(dir.join(".cache"))
+            .ok()?
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| p.extension().is_some_and(|x| x == "flac"))
+    }
+
+    /// Decode FLAC bytes with symphonia; return the per-channel frame count.
+    fn decode_frames(flac: &[u8]) -> u64 {
+        use symphonia::core::codecs::DecoderOptions;
+        let mss = MediaSourceStream::new(
+            Box::new(std::io::Cursor::new(flac.to_vec())),
+            Default::default(),
+        );
+        let mut hint = Hint::new();
+        hint.with_extension("flac");
+        let probed = symphonia::default::get_probe()
+            .format(
+                &hint,
+                mss,
+                &FormatOptions::default(),
+                &MetadataOptions::default(),
+            )
+            .expect("recorded file must be valid FLAC");
+        let mut format = probed.format;
+        let (track_id, params) = first_audio_track(format.as_ref()).unwrap();
+        let mut decoder = symphonia::default::get_codecs()
+            .make(&params, &DecoderOptions::default())
+            .unwrap();
+        let mut frames = 0u64;
+        while let Ok(packet) = format.next_packet() {
+            if packet.track_id() != track_id {
+                continue;
+            }
+            if let Ok(d) = decoder.decode(&packet) {
+                frames += d.frames() as u64;
+            }
+        }
+        frames
+    }
+
+    /// Record a real song from the live Opus stream and verify the resulting file is
+    /// a complete, decodable FLAC. Slow: it must span two song boundaries.
+    #[test]
+    #[ignore = "network: records a live song end-to-end (slow, up to several minutes)"]
+    fn records_a_live_song_to_a_valid_flac() {
+        let dir = std::env::temp_dir().join(format!("plaza_rec_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let recorder = Recorder::spawn(RecordingConfig {
+            mode: RecordMode::Cache,
+            root: dir.clone(),
+            cache_size: 5,
+            embed_artwork: false,
+            deduplicate: false,
+        });
+        let mut source = OpusPcmSource::open(
+            StreamQuality::Ogg.stream_url().to_string(),
+            Some(recorder.handle()),
+        )
+        .expect("open opus source");
+
+        let start = Instant::now();
+        let mut saved = None;
+        while start.elapsed() < Duration::from_secs(480) {
+            if source.next_chunk().is_err() {
+                break;
+            }
+            if let Some(p) = first_flac(&dir) {
+                std::thread::sleep(Duration::from_millis(300)); // let the rename settle
+                saved = Some(p);
+                break;
+            }
+        }
+        drop(source);
+        drop(recorder);
+
+        let path = saved.expect("a full song should have been recorded within the time limit");
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(&bytes[0..4], b"fLaC");
+        // A real song is far longer than a few seconds of audio.
+        assert!(
+            decode_frames(&bytes) > 200_000,
+            "recorded song unexpectedly short"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/plaza-audio/src/sources.rs
+++ b/crates/plaza-audio/src/sources.rs
@@ -20,17 +20,24 @@ use symphonia::core::probe::Hint;
 use crate::hls::HlsAacPcmSource;
 use crate::pcm::{PcmChunk, PcmError, PcmSource};
 use crate::quality::StreamQuality;
+use crate::recording::{RecordHandle, SongTags};
 
 /// Build the live [`PcmSource`] for a stream quality, opening the network
 /// connection. A failure to open is returned as [`PcmError`] so the player can
 /// decide whether to retry (transient) or stop (permanent).
-pub fn build_live_source(quality: &StreamQuality) -> Result<Box<dyn PcmSource>, PcmError> {
+///
+/// `rec` is wired into the Opus source only — it's the one format with exact
+/// in-band song boundaries, so it's the only one that can record correctly.
+pub(crate) fn build_live_source(
+    quality: &StreamQuality,
+    rec: Option<RecordHandle>,
+) -> Result<Box<dyn PcmSource>, PcmError> {
     let url = quality.stream_url().to_string();
     match quality {
         StreamQuality::Mp3 | StreamQuality::Mp3Low => {
             Ok(Box::new(SymphoniaPcmSource::open(url, "audio/mpeg")?))
         }
-        StreamQuality::Ogg | StreamQuality::OggLow => Ok(Box::new(OpusPcmSource::open(url)?)),
+        StreamQuality::Ogg | StreamQuality::OggLow => Ok(Box::new(OpusPcmSource::open(url, rec)?)),
         StreamQuality::Hls => Ok(Box::new(HlsAacPcmSource::open(url)?)),
     }
 }
@@ -218,21 +225,27 @@ const OPUS_MAX_FRAME: usize = 5760; // 120ms @ 48kHz, per channel
 
 /// A [`PcmSource`] for Ogg/Opus: symphonia demuxes the container and libopus
 /// decodes the packets.
+///
+/// Each Plaza song is its own chained-Ogg logical stream, so a stream reset marks
+/// an exact song boundary. When recording, this source brackets each song with
+/// begin/finish events and forwards the decoded samples — the boundary precision
+/// that makes lossless splitting possible.
 pub struct OpusPcmSource {
     format: Box<dyn FormatReader>,
     decoder: opus::Decoder,
     track_id: u32,
     channels: u16,
     out: Vec<f32>,
+    rec: Option<RecordHandle>,
 }
 
 impl OpusPcmSource {
-    /// Open an Ogg/Opus stream at `url`.
+    /// Open an Ogg/Opus stream at `url`, optionally feeding `rec` with recording events.
     ///
     /// # Errors
     /// [`PcmError::Ended`] for a connection/probe failure (the player retries) and
     /// [`PcmError::Permanent`] if an Opus decoder cannot be created.
-    pub fn open(url: String) -> Result<Self, PcmError> {
+    pub fn open(url: String, rec: Option<RecordHandle>) -> Result<Self, PcmError> {
         let mss = open_http_media(&url)?;
         let mut hint = Hint::new();
         hint.mime_type("audio/ogg");
@@ -244,18 +257,53 @@ impl OpusPcmSource {
                 &MetadataOptions::default(),
             )
             .map_err(|_| PcmError::Ended)?;
-        let format = probed.format;
+        let mut format = probed.format;
         let (track_id, params) = first_audio_track(format.as_ref()).ok_or(PcmError::Ended)?;
         let channels = params.channels.map(|c| c.count() as u16).unwrap_or(2);
         let decoder = make_opus_decoder(channels)?;
+
+        // The song already playing when we connect is captured mid-way, so it is not
+        // savable; only songs we see from their start (after a reset) are.
+        if rec.as_ref().is_some_and(RecordHandle::is_active) {
+            let tags = read_tags(format.as_mut());
+            if let Some(r) = &rec {
+                r.begin(tags, false);
+            }
+        }
+
         Ok(OpusPcmSource {
             format,
             decoder,
             track_id,
             channels,
             out: vec![0.0; OPUS_MAX_FRAME * channels.max(1) as usize],
+            rec,
         })
     }
+
+    /// Whether recording is on; gates the per-chunk sample clone.
+    fn recording(&self) -> bool {
+        self.rec.as_ref().is_some_and(RecordHandle::is_active)
+    }
+}
+
+/// Read artist/album/title from the format reader's current metadata revision
+/// (the Ogg/Opus `OpusTags`).
+fn read_tags(format: &mut dyn FormatReader) -> SongTags {
+    use symphonia::core::meta::StandardTagKey;
+    let mut tags = SongTags::default();
+    let metadata = format.metadata();
+    if let Some(rev) = metadata.current() {
+        for tag in rev.tags() {
+            match tag.std_key {
+                Some(StandardTagKey::Artist) => tags.artist = Some(tag.value.to_string()),
+                Some(StandardTagKey::Album) => tags.album = Some(tag.value.to_string()),
+                Some(StandardTagKey::TrackTitle) => tags.title = Some(tag.value.to_string()),
+                _ => {}
+            }
+        }
+    }
+    tags
 }
 
 fn make_opus_decoder(channels: u16) -> Result<opus::Decoder, PcmError> {
@@ -273,9 +321,24 @@ impl PcmSource for OpusPcmSource {
             let packet = match self.format.next_packet() {
                 Ok(p) => p,
                 Err(SymphoniaError::ResetRequired) => {
-                    // New logical Opus stream: refresh track/channel layout.
-                    let (track_id, params) =
-                        first_audio_track(self.format.as_ref()).ok_or(PcmError::Ended)?;
+                    // A new logical stream is an exact song boundary: the previous
+                    // song ended cleanly here.
+                    if let Some(r) = &self.rec {
+                        if r.is_active() {
+                            r.finish();
+                        }
+                    }
+                    let (track_id, params) = match first_audio_track(self.format.as_ref()) {
+                        Some(t) => t,
+                        None => {
+                            if let Some(r) = &self.rec {
+                                if r.is_active() {
+                                    r.abort();
+                                }
+                            }
+                            return Err(PcmError::Ended);
+                        }
+                    };
                     self.track_id = track_id;
                     let channels = params.channels.map(|c| c.count() as u16).unwrap_or(2);
                     if channels != self.channels {
@@ -283,9 +346,24 @@ impl PcmSource for OpusPcmSource {
                         self.decoder = make_opus_decoder(channels)?;
                         self.out = vec![0.0; OPUS_MAX_FRAME * channels.max(1) as usize];
                     }
+                    // The next song is captured from its start, so it is savable.
+                    if self.recording() {
+                        let tags = read_tags(self.format.as_mut());
+                        if let Some(r) = &self.rec {
+                            r.begin(tags, true);
+                        }
+                    }
                     continue;
                 }
-                Err(_) => return Err(PcmError::Ended),
+                Err(_) => {
+                    // The stream dropped mid-song; that capture is incomplete.
+                    if let Some(r) = &self.rec {
+                        if r.is_active() {
+                            r.abort();
+                        }
+                    }
+                    return Err(PcmError::Ended);
+                }
             };
             if packet.track_id() != self.track_id {
                 continue;
@@ -300,11 +378,14 @@ impl PcmSource for OpusPcmSource {
                     if n == 0 {
                         continue;
                     }
-                    return Ok(Some(PcmChunk::new(
-                        self.out[..n].to_vec(),
-                        OPUS_SAMPLE_RATE,
-                        self.channels,
-                    )));
+                    let chunk =
+                        PcmChunk::new(self.out[..n].to_vec(), OPUS_SAMPLE_RATE, self.channels);
+                    if self.recording() {
+                        if let Some(r) = &self.rec {
+                            r.samples(chunk.clone());
+                        }
+                    }
+                    return Ok(Some(chunk));
                 }
                 // A corrupt packet shouldn't kill the stream; skip it.
                 Err(_) => continue,

--- a/crates/plaza-audio/tests/stream_smoke_test.rs
+++ b/crates/plaza-audio/tests/stream_smoke_test.rs
@@ -158,7 +158,7 @@ fn test_mp3_source_decodes() {
 fn test_opus_source_decodes() {
     use plaza_audio::sources::OpusPcmSource;
     let url = plaza_audio::StreamQuality::Ogg.stream_url().to_string();
-    let source = OpusPcmSource::open(url).expect("open opus source");
+    let source = OpusPcmSource::open(url, None).expect("open opus source");
     let (t, nz) = drain_source(Box::new(source), 400);
     assert_audible("Opus source", t, nz);
 }

--- a/crates/plaza-tui/src/app.rs
+++ b/crates/plaza-tui/src/app.rs
@@ -111,6 +111,11 @@ pub struct AppState {
     pub pending_audio: Option<PendingAudioCommand>,
     /// Artwork URL of the currently displayed song (used to detect song changes).
     pub artwork_url: Option<String>,
+    /// When the sleep timer should stop playback, if it is armed.
+    pub sleep_deadline: Option<Instant>,
+    /// The sleep timer's selected duration, retained so the key can cycle through
+    /// the presets.
+    pub sleep_total: Option<Duration>,
 }
 
 impl AppState {
@@ -142,6 +147,8 @@ impl AppState {
             show_logout_confirm: false,
             pending_audio: None,
             artwork_url: None,
+            sleep_deadline: None,
+            sleep_total: None,
         }
     }
 
@@ -155,6 +162,53 @@ impl AppState {
                 self.notification = None;
             }
         }
+    }
+
+    /// Advance the sleep timer through its presets (off → 15m → 30m → 60m → off),
+    /// arming or disarming it and notifying the user of the new setting.
+    pub fn cycle_sleep_timer(&mut self) {
+        self.sleep_total = next_sleep_duration(self.sleep_total);
+        self.sleep_deadline = self.sleep_total.map(|d| Instant::now() + d);
+        match self.sleep_total {
+            Some(d) => self.notify(format!("Sleep timer: {} min", d.as_secs() / 60)),
+            None => self.notify("Sleep timer off"),
+        }
+    }
+
+    /// Time left on the sleep timer, if it is armed.
+    pub fn sleep_remaining(&self) -> Option<Duration> {
+        self.sleep_deadline
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+    }
+
+    /// If the sleep timer has elapsed, disarm it and pause playback. Returns whether
+    /// it fired this tick.
+    pub fn tick_sleep_timer(&mut self) -> bool {
+        match self.sleep_deadline {
+            Some(deadline) if Instant::now() >= deadline => {
+                self.sleep_deadline = None;
+                self.sleep_total = None;
+                if self.is_playing {
+                    self.pending_audio = Some(PendingAudioCommand::Pause);
+                }
+                self.notify("Sleep timer ended — paused");
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+/// The next sleep-timer preset, cycling off → 15m → 30m → 60m → off.
+fn next_sleep_duration(current: Option<Duration>) -> Option<Duration> {
+    const FIFTEEN: u64 = 15 * 60;
+    const THIRTY: u64 = 30 * 60;
+    const SIXTY: u64 = 60 * 60;
+    match current.map(|d| d.as_secs()) {
+        None => Some(Duration::from_secs(FIFTEEN)),
+        Some(FIFTEEN) => Some(Duration::from_secs(THIRTY)),
+        Some(THIRTY) => Some(Duration::from_secs(SIXTY)),
+        _ => None,
     }
 }
 
@@ -485,6 +539,7 @@ pub async fn run(config: Config, mut api: ApiClient) -> anyhow::Result<()> {
             EventAction::Quit => break,
         }
 
+        state.tick_sleep_timer();
         state.clear_expired_notification();
     }
 
@@ -563,6 +618,9 @@ async fn handle_event(event: AppEvent, state: &mut AppState, api: &mut ApiClient
                 KeyCode::Char('q') if state.view != View::Login => return EventAction::Quit,
                 KeyCode::Char('?') if state.view != View::Login => {
                     state.show_help = !state.show_help;
+                }
+                KeyCode::Char('t') if state.view != View::Login => {
+                    state.cycle_sleep_timer();
                 }
                 KeyCode::Char('1') if state.view != View::Login => {
                     state.view = View::NowPlaying;
@@ -1234,6 +1292,13 @@ fn render_status_bar(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, st
         ""
     };
     let volume = format!(" | Vol: {:.0}%", state.volume * 100.0);
+    let sleep = state
+        .sleep_remaining()
+        .map(|left| {
+            let secs = left.as_secs();
+            format!(" | \u{1f4a4} {}:{:02}", secs / 60, secs % 60)
+        })
+        .unwrap_or_default();
     let auth_note = if !state.is_authenticated {
         " | Guest"
     } else {
@@ -1256,6 +1321,7 @@ fn render_status_bar(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, st
             ratatui::style::Style::default().fg(Theme::GREEN),
         ),
         Span::styled(&volume, Theme::dim()),
+        Span::styled(&sleep, ratatui::style::Style::default().fg(Theme::PURPLE)),
         Span::styled(auth_note, Theme::dim()),
         Span::styled(
             &notification,
@@ -1266,4 +1332,32 @@ fn render_status_bar(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, st
 
     let para = Paragraph::new(line).style(ratatui::style::Style::default().bg(Theme::BACKGROUND));
     frame.render_widget(para, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sleep_timer_cycles_through_presets_and_back_to_off() {
+        let mins = |d: Option<Duration>| d.map(|d| d.as_secs() / 60);
+
+        let fifteen = next_sleep_duration(None);
+        assert_eq!(mins(fifteen), Some(15));
+
+        let thirty = next_sleep_duration(fifteen);
+        assert_eq!(mins(thirty), Some(30));
+
+        let sixty = next_sleep_duration(thirty);
+        assert_eq!(mins(sixty), Some(60));
+
+        // After the longest preset it wraps back to off.
+        assert_eq!(next_sleep_duration(sixty), None);
+    }
+
+    #[test]
+    fn sleep_timer_off_is_the_terminal_state_for_unknown_durations() {
+        // A value that isn't one of the presets disarms rather than getting stuck.
+        assert_eq!(next_sleep_duration(Some(Duration::from_secs(42))), None);
+    }
 }

--- a/crates/plaza-tui/src/app.rs
+++ b/crates/plaza-tui/src/app.rs
@@ -1091,6 +1091,17 @@ async fn handle_list_key(
                 Err(e) => state.notify(format!("Error: {}", e)),
             }
         }
+        KeyCode::Char('e') if view_name == "favorites" => {
+            if state.is_authenticated {
+                tracing::info!("Exporting favorites");
+                match api.export_favorites().await {
+                    Ok(link) => state.notify(format!("Export ready: {link}")),
+                    Err(e) => state.notify(format!("Export failed: {e}")),
+                }
+            } else {
+                state.notify("Login required to export favorites");
+            }
+        }
         KeyCode::Char('h') | KeyCode::Left if view_name == "charts" => {
             state.chart_range = match state.chart_range {
                 RatingRange::Overtime => RatingRange::Monthly,

--- a/crates/plaza-tui/src/app.rs
+++ b/crates/plaza-tui/src/app.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc;
 
 use plaza_api::models::*;
 use plaza_api::{auth, ApiClient, SocketClient, SocketEvent};
-use plaza_audio::Player;
+use plaza_audio::{Player, RecordMode};
 
 use crate::config::Config;
 use crate::tui::events::{AppEvent, EventHandler};
@@ -31,6 +31,15 @@ pub enum PendingAudioCommand {
     Pause,
     Resume,
     SetVolume(f32),
+}
+
+/// A recording control queued by a key handler and applied (with the player) in
+/// the main loop.
+pub enum RecordingAction {
+    /// Cycle the recording mode (off → cache → session → off).
+    Cycle,
+    /// Promote the most recently cached song into the library.
+    Keep,
 }
 
 #[derive(Debug, Clone)]
@@ -116,6 +125,10 @@ pub struct AppState {
     /// The sleep timer's selected duration, retained so the key can cycle through
     /// the presets.
     pub sleep_total: Option<Duration>,
+    /// Current recording mode, mirrored from the player for display.
+    pub recording_mode: RecordMode,
+    /// A recording control awaiting the next main-loop iteration.
+    pub pending_recording: Option<RecordingAction>,
 }
 
 impl AppState {
@@ -149,6 +162,8 @@ impl AppState {
             artwork_url: None,
             sleep_deadline: None,
             sleep_total: None,
+            recording_mode: config.recording.mode,
+            pending_recording: None,
         }
     }
 
@@ -245,6 +260,8 @@ pub async fn run(config: Config, mut api: ApiClient) -> anyhow::Result<()> {
         p.on_error(move |msg| {
             let _ = tx.try_send(msg);
         });
+        // Spawn the recorder up front (even when off) so it can be toggled at runtime.
+        p.configure_recording(config.recording.to_config());
     }
     let _audio_error_tx = audio_error_tx; // keep alive so channel never auto-closes
 
@@ -331,6 +348,7 @@ pub async fn run(config: Config, mut api: ApiClient) -> anyhow::Result<()> {
     let mut prev_show_help = false;
     let mut prev_show_popup = false;
     let mut prev_popup_song_id: Option<String> = None;
+    let mut last_recorded_artwork: Option<String> = None;
     loop {
         // Check if the song changed and we need to fetch new artwork
         if state.artwork_url.as_deref() != current_artwork_url.as_deref() {
@@ -518,6 +536,38 @@ pub async fn run(config: Config, mut api: ApiClient) -> anyhow::Result<()> {
             }
         }
 
+        // Process pending recording control from a key handler.
+        if let Some(action) = state.pending_recording.take() {
+            if let Some(ref mut p) = player {
+                match action {
+                    RecordingAction::Cycle => {
+                        let mode = p.cycle_recording_mode();
+                        state.recording_mode = mode;
+                        if mode != RecordMode::Off && !stream_quality.is_recordable() {
+                            state
+                                .notify("Recording on — switch to the OGG stream to capture songs");
+                        } else {
+                            state.notify(format!("Recording: {}", mode.label()));
+                        }
+                    }
+                    RecordingAction::Keep => {
+                        p.keep_recording();
+                        state.notify("Keeping the last recorded song");
+                    }
+                }
+            } else {
+                state.notify("No audio output — recording unavailable");
+            }
+        }
+
+        // Keep the recorder's artwork in sync with the now-playing song.
+        if state.artwork_url != last_recorded_artwork {
+            last_recorded_artwork = state.artwork_url.clone();
+            if let Some(ref p) = player {
+                p.set_now_playing_artwork(state.artwork_url.clone());
+            }
+        }
+
         // Force full terminal clear when any overlay is dismissed to erase stale cells.
         let show_popup = state.show_song_detail.is_some();
         if (prev_show_help && !state.show_help) || (prev_show_popup && !show_popup) {
@@ -621,6 +671,12 @@ async fn handle_event(event: AppEvent, state: &mut AppState, api: &mut ApiClient
                 }
                 KeyCode::Char('t') if state.view != View::Login => {
                     state.cycle_sleep_timer();
+                }
+                KeyCode::Char('R') if state.view != View::Login => {
+                    state.pending_recording = Some(RecordingAction::Cycle);
+                }
+                KeyCode::Char('s') if state.view != View::Login => {
+                    state.pending_recording = Some(RecordingAction::Keep);
                 }
                 KeyCode::Char('1') if state.view != View::Login => {
                     state.view = View::NowPlaying;
@@ -1310,6 +1366,11 @@ fn render_status_bar(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, st
             format!(" | \u{1f4a4} {}:{:02}", secs / 60, secs % 60)
         })
         .unwrap_or_default();
+    let recording = if state.recording_mode == RecordMode::Off {
+        String::new()
+    } else {
+        format!(" | \u{25cf} REC {}", state.recording_mode.label())
+    };
     let auth_note = if !state.is_authenticated {
         " | Guest"
     } else {
@@ -1333,6 +1394,7 @@ fn render_status_bar(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, st
         ),
         Span::styled(&volume, Theme::dim()),
         Span::styled(&sleep, ratatui::style::Style::default().fg(Theme::PURPLE)),
+        Span::styled(&recording, ratatui::style::Style::default().fg(Theme::RED)),
         Span::styled(auth_note, Theme::dim()),
         Span::styled(
             &notification,

--- a/crates/plaza-tui/src/config.rs
+++ b/crates/plaza-tui/src/config.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use plaza_audio::StreamQuality;
+use plaza_audio::{RecordMode, RecordingConfig, StreamQuality};
 use serde::{Deserialize, Serialize};
 
 /// Persistent user settings.
@@ -19,6 +19,9 @@ pub struct Config {
     /// `None` auto-detects.
     #[serde(default)]
     pub image_protocol: Option<String>,
+    /// Song-recording settings.
+    #[serde(default)]
+    pub recording: RecordingSettings,
 }
 
 fn default_volume() -> f32 {
@@ -31,8 +34,76 @@ impl Default for Config {
             stream_quality: StreamQuality::default(),
             volume: default_volume(),
             image_protocol: None,
+            recording: RecordingSettings::default(),
         }
     }
+}
+
+/// Settings for recording songs from the live stream to a local FLAC library.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordingSettings {
+    /// What to do with completed songs: `off`, `cache`, or `session`.
+    #[serde(default)]
+    pub mode: RecordMode,
+    /// Library directory; empty means `<audio dir>/Plaza`.
+    #[serde(default)]
+    pub directory: Option<String>,
+    /// How many songs the rolling cache keeps.
+    #[serde(default = "default_cache_size")]
+    pub cache_size: usize,
+    /// Download and embed cover art.
+    #[serde(default = "default_true")]
+    pub embed_artwork: bool,
+    /// Skip re-saving a song already in the library.
+    #[serde(default = "default_true")]
+    pub deduplicate: bool,
+}
+
+fn default_cache_size() -> usize {
+    20
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for RecordingSettings {
+    fn default() -> Self {
+        RecordingSettings {
+            mode: RecordMode::Off,
+            directory: None,
+            cache_size: default_cache_size(),
+            embed_artwork: true,
+            deduplicate: true,
+        }
+    }
+}
+
+impl RecordingSettings {
+    /// Resolve these settings into a [`RecordingConfig`] for the audio engine.
+    pub fn to_config(&self) -> RecordingConfig {
+        let root = self
+            .directory
+            .as_ref()
+            .filter(|d| !d.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(default_recording_root);
+        RecordingConfig {
+            mode: self.mode,
+            root,
+            cache_size: self.cache_size,
+            embed_artwork: self.embed_artwork,
+            deduplicate: self.deduplicate,
+        }
+    }
+}
+
+/// Default recording library: the platform music directory's `Plaza` folder.
+fn default_recording_root() -> PathBuf {
+    dirs::audio_dir()
+        .or_else(dirs::data_local_dir)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Plaza")
 }
 
 impl Config {

--- a/crates/plaza-tui/src/tui/views/help.rs
+++ b/crates/plaza-tui/src/tui/views/help.rs
@@ -35,6 +35,7 @@ pub fn render(frame: &mut Frame, area: ratatui::layout::Rect, _state: &AppState)
         ("r", "Send reaction"),
         ("h / l", "Previous / next tab (Charts)"),
         ("d", "Remove favorite"),
+        ("t", "Sleep timer (off / 15 / 30 / 60 min)"),
         ("L", "Logout (Profile view)"),
         ("?", "Toggle this help"),
         ("q", "Quit"),

--- a/crates/plaza-tui/src/tui/views/help.rs
+++ b/crates/plaza-tui/src/tui/views/help.rs
@@ -37,6 +37,8 @@ pub fn render(frame: &mut Frame, area: ratatui::layout::Rect, _state: &AppState)
         ("d", "Remove favorite"),
         ("e", "Export favorites (Favorites view)"),
         ("t", "Sleep timer (off / 15 / 30 / 60 min)"),
+        ("R", "Cycle recording (off / cache / session)"),
+        ("s", "Keep last recorded song"),
         ("L", "Logout (Profile view)"),
         ("?", "Toggle this help"),
         ("q", "Quit"),

--- a/crates/plaza-tui/src/tui/views/help.rs
+++ b/crates/plaza-tui/src/tui/views/help.rs
@@ -35,6 +35,7 @@ pub fn render(frame: &mut Frame, area: ratatui::layout::Rect, _state: &AppState)
         ("r", "Send reaction"),
         ("h / l", "Previous / next tab (Charts)"),
         ("d", "Remove favorite"),
+        ("e", "Export favorites (Favorites view)"),
         ("t", "Sleep timer (off / 15 / 30 / 60 min)"),
         ("L", "Logout (Profile view)"),
         ("?", "Toggle this help"),

--- a/crates/plaza-tui/tests/config_test.rs
+++ b/crates/plaza-tui/tests/config_test.rs
@@ -22,6 +22,7 @@ fn test_config_round_trip() {
         stream_quality: StreamQuality::Ogg,
         volume: 0.65,
         image_protocol: Some("kitty".to_string()),
+        recording: Default::default(),
     };
 
     write_config_to(&dir, &original);
@@ -78,6 +79,7 @@ fn test_config_serialize_deserialize_all_qualities() {
             stream_quality: quality,
             volume: 0.5,
             image_protocol: None,
+            recording: Default::default(),
         };
         let serialized = toml::to_string_pretty(&config).unwrap();
         let deserialized: Config = toml::from_str(&serialized).unwrap();

--- a/tasks/recording-design.md
+++ b/tasks/recording-design.md
@@ -1,0 +1,133 @@
+# Stream Recording → Local FLAC Library — Design
+
+Capture full songs from the live stream as they play and build a local, properly
+tagged FLAC library. This is the foundation for an on-demand local library and real
+playlists (see the roadmap at the end).
+
+## Non-negotiable correctness guarantee
+
+**A saved file is always exactly one complete song — or it is not saved at all.**
+Never a truncated song, never a premature cut, never two songs in one file, never a
+corrupt container. We would rather drop a recording than persist a bad one.
+
+This single rule drives every decision below.
+
+### How we guarantee it
+
+1. **Split only on exact, in-band boundaries** — never on a wall-clock guess or the
+   (latency-skewed) socket metadata. The boundary must come from the audio stream
+   itself, at the precise sample where one song ends and the next begins.
+2. **Atomic writes** — encode to a temporary file (`.partial`) and `rename()` it into
+   the library only after a *clean* finalize at a confirmed boundary. A crash or
+   stream drop leaves only a discarded `.partial`; the library never contains a
+   half-written file.
+3. **Discard incomplete songs** — if the stream drops mid-song (we never see the
+   song's end boundary), that recording is discarded, not saved. An incomplete song
+   is worse than no song. Only a song captured start-boundary → end-boundary is kept.
+4. **One song per file, by construction** — because we cut exactly at boundaries and
+   start a fresh encoder per song, a file physically cannot contain two songs.
+5. **Verify on finalize** — after encoding, confirm the FLAC decodes and its duration
+   is sane before promoting it. A file that fails verification is discarded.
+
+## Per-stream support (gated on splitting correctness)
+
+We support recording **only where we can guarantee exact boundaries**. Where we
+can't, recording is refused with a clear message — never attempted with ragged cuts.
+
+| Stream | Boundary source | Recording |
+|---|---|---|
+| Opus — `/ogg`, `/ogg_low` | Chained-Ogg logical-stream boundary (the decoder reset we already handle) — exact | **v1** |
+| MP3 — `/mp3`, `/mp3_low` | Icecast inline metadata (`Icy-MetaData`, `StreamTitle` at `icy-metaint`) — exact | **v1.1** |
+| HLS — `/hls` | No reliable per-song boundary in-band | **Unsupported** |
+
+### Do we force `stream_quality = "ogg"`?
+
+No — but recording is **gated** on the active stream being splittable. If a user
+enables recording while on HLS (or MP3 before v1.1), we do **not** silently produce
+bad files and we do **not** silently change their setting. We show a clear notice:
+*"Recording needs the OGG stream — set `stream_quality = ogg` to record."* Correct
+files or none; never bad ones.
+
+## Boundary + metadata (Opus, v1)
+
+- **Boundary:** symphonia surfaces each chained-Ogg song as a new logical bitstream
+  (`ResetRequired`). All PCM decoded *before* the reset is song A in full; PCM after
+  is song B. This is sample-exact and free — we already handle it in the decode loop.
+- **Metadata for naming/tags — CONFIRMED in-band.** A 5-minute live capture
+  (2026-06-11) showed each song is a separate Ogg logical stream carrying its own
+  `OpusTags` with `artist`, `album`, and `title`. We read these directly (symphonia
+  surfaces them as metadata revisions on each stream reset), so naming and tagging
+  are exact and need no socket correlation. The socket is not in the recorder's path
+  at all — verified boundaries (BOS/EOS per song) + verified in-band tags.
+
+## Filesystem layout & naming
+
+- **Root:** configurable; default `<audio-dir>/Plaza/` (XDG `MUSIC`, else data dir).
+- **Library path:** `<root>/<Artist>/<Album>/<Artist> - <Title>.flac`.
+  - Standard artist/album tree so any music player (Plex, Navidrome, Jellyfin, …)
+    indexes it cleanly.
+  - Missing album → `Unknown Album`; missing artist → `Unknown Artist`.
+  - Every path component is sanitized: strip `/\:*?"<>|` and control chars, trim
+    trailing dots/spaces, collapse whitespace, cap length, never empty.
+- **Dedup:** if the target file already exists, skip (we already have that track).
+  Configurable, so a user can choose to keep duplicates.
+- **Cover art:** download `artwork_src`, embed it as a FLAC `PICTURE` block, and also
+  drop `cover.jpg` in the album folder (the convention players auto-detect).
+- **Tags (Vorbis comments):** `ARTIST`, `ALBUM`, `TITLE`, plus a `COMMENT`/`SOURCE`
+  noting it came from Nightwave Plaza and the capture date.
+
+> Implementation note: `flacenc` (pure Rust) encodes the audio; FLAC metadata blocks
+> (`VORBIS_COMMENT`, `PICTURE`) are a simple, well-specified format we can write
+> ourselves if the crate doesn't expose them. To verify during implementation.
+
+## Recording modes
+
+- **off** (default) — no recording.
+- **cache** — a rolling cache of the last *N* complete songs in a cache dir; oldest
+  evicted past *N*. For "I liked that, let me grab it" after the fact.
+- **session** — every complete song goes straight to the permanent library.
+
+Plus a **keep** action (key) that promotes the current/last cached song into the
+permanent library so the rolling cache won't evict it.
+
+## Config (`[recording]`)
+
+```toml
+[recording]
+mode = "off"            # off | cache | session
+root = ""               # "" = <audio-dir>/Plaza
+cache_size = 20         # rolling-cache song count
+embed_artwork = true
+deduplicate = true
+```
+
+## What this unlocks (why it's the keystone feature)
+
+Once a local library of full FLAC files exists, on-demand features that a *live*
+radio can't otherwise offer become possible:
+
+- **Local library browser** — a new view to browse/search what you've recorded.
+- **On-demand local playback** — a local-file `PcmSource` (symphonia decodes FLAC)
+  plays library tracks through the existing `Player`. The radio client gains an
+  on-demand mode.
+- **Real playlists** — create/save/play playlists from the library (the original
+  "playlists" idea, now actually playable).
+- **Auto-keep favorites** — when a track you've favorited comes on the radio, keep it
+  to the library automatically.
+- **"In your library" indicator** — show on Now Playing whether the current song is
+  already saved locally.
+
+## Roadmap (sequenced)
+
+- **3a — Recorder v1 (Opus):** decode-tap recorder, exact Ogg-boundary splitting,
+  atomic writes, FLAC encode + tags + embedded/sidecar art, cache/session modes,
+  keep key, config, status indicator. Tests: boundary→file mapping, sanitizer,
+  atomic-finalize/discard-on-incomplete, FLAC round-trip.
+- **3b — MP3 recording:** add `Icy-MetaData` parsing to the MP3 source for exact
+  boundaries + titles.
+- **3c — Local library + on-demand playback:** library index, browser view, local
+  FLAC `PcmSource`, play recorded tracks on demand.
+- **3d — Local playlists:** build/save/play playlists from the library.
+- **3e — Niceties:** auto-keep favorites, "in your library" indicator, library stats.
+
+(HLS recording remains unsupported until/unless a reliable boundary signal exists.)

--- a/tasks/roadmap.md
+++ b/tasks/roadmap.md
@@ -21,8 +21,11 @@ priority and dependency.
 ### Recording → local FLAC library (the keystone) — see `recording-design.md`
 Capture full songs from the live stream into a tagged FLAC library. Correctness is
 non-negotiable: exact in-band splits, atomic writes, discard incomplete songs.
-- **3a** Recorder v1 (Opus): exact Ogg-boundary splitting, FLAC encode, in-band tags
-  + embedded/sidecar cover art, cache/session modes, keep key, config, status.
+- **3a DONE** Recorder v1 (Opus): exact Ogg-boundary splitting, FLAC encode (with a
+  STREAMINFO fix-up so symphonia can read it back), in-band OpusTags, embedded cover
+  art, off/cache/session modes, `R` cycle + `s` keep keys, `[recording]` config,
+  status indicator. Validated end-to-end against the live stream (records a real song
+  to a valid, decodable FLAC). Recording is gated to Opus.
 - **3b** MP3 recording via `Icy-MetaData`.
 - **3c** Local library + on-demand playback (local FLAC `PcmSource`, browser view).
 - **3d** Local playlists (build / save / play from the library).

--- a/tasks/roadmap.md
+++ b/tasks/roadmap.md
@@ -1,0 +1,41 @@
+# Plaza TUI — Development Roadmap
+
+A living roadmap. Done items stay for context; upcoming items are ordered roughly by
+priority and dependency.
+
+## Done
+
+- **Audio fixes** — restored playback (Plaza moved `/ogg` to Opus), killed the
+  reconnect storm, fixed `_low` URLs, hardened key input.
+- **Full codec parity** — MP3, Opus (libopus), and HLS/AAC (MPEG-TS demux), behind a
+  codec-agnostic `PcmSource` layer; HLS drop-out + drift fix (bounded-latency,
+  background-fetch design).
+- **Productionization** — Cargo workspace (`plaza-api`, `plaza-audio`, `plaza-tui`),
+  per-crate `thiserror`, full public-API docs, clippy `-D warnings` clean, CI across
+  Linux/macOS/Windows, `justfile`, README + dual license.
+- **Sleep timer** — `t` cycles off / 15 / 30 / 60 min; pauses on elapse.
+- **Favorites export** — `e` triggers Plaza's CSV export and surfaces the link.
+
+## In progress / next
+
+### Recording → local FLAC library (the keystone) — see `recording-design.md`
+Capture full songs from the live stream into a tagged FLAC library. Correctness is
+non-negotiable: exact in-band splits, atomic writes, discard incomplete songs.
+- **3a** Recorder v1 (Opus): exact Ogg-boundary splitting, FLAC encode, in-band tags
+  + embedded/sidecar cover art, cache/session modes, keep key, config, status.
+- **3b** MP3 recording via `Icy-MetaData`.
+- **3c** Local library + on-demand playback (local FLAC `PcmSource`, browser view).
+- **3d** Local playlists (build / save / play from the library).
+- **3e** Auto-keep favorites; "in your library" indicator; library stats.
+
+### Remaining API / UX parity (independent, pick up between recorder phases)
+- News "latest/unread" badge.
+- Account: register, profile edit, change password, delete account.
+- UX polish: volume OSD overlay, scrolling marquee for long header titles.
+
+## Notes / constraints
+
+- Plaza is **live radio** — no on-demand catalog and no full-track download API. The
+  recorder is what makes an on-demand local library (and real playlists) possible.
+- HLS has no reliable in-band song boundary, so recording is Opus/MP3 only.
+- No song-search / artist-page / request APIs exist server-side; those aren't buildable.


### PR DESCRIPTION
## Summary

Phase 3 features on top of the productionized workspace.

- **Sleep timer** — `t` cycles off / 15 / 30 / 60 minutes; pauses playback on elapse,
  with a status-bar countdown.
- **Favorites export** — `e` triggers Plaza's CSV export and surfaces the link.
- **Stream recorder → local FLAC library** — capture full songs from the live Opus
  stream into a tagged FLAC library:
  - Exact in-band song splitting (chained-Ogg boundaries), atomic writes, and
    discard-on-incomplete, so a saved file is always exactly one complete song.
  - In-band OpusTags (artist/album/title), embedded cover art, artist/album folder
    tree, dedup.
  - off / cache (rolling last N) / session modes; `R` cycles, `s` keeps the last
    cached song. `[recording]` config section. Gated to the Opus stream.
  - A FLAC encoder built on flacenc, with a STREAMINFO fix-up so the output decodes
    in symphonia (needed for the coming on-demand local playback).

Validated end-to-end against the live stream (an ignored test records a real song
to a valid, decodable FLAC). All four gates pass: fmt, clippy -D warnings, tests,
and doc.
